### PR TITLE
Fix/cluster loading refresh bug

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,15 @@
 {
   "permissions": {
     "allow": [
-      "Bash(make test)",
-      "Bash(go build ./...)",
-      "Bash(go test ./pkg/nsk ./pkg/kubernetes ./pkg/mcp -v)"
+      "mcp__kubernetes-mcp-server__configuration_view",
+      "mcp__kubernetes-mcp-server__namespaces_list",
+      "mcp__kubernetes-mcp-server__clusters_list",
+      "mcp__kubernetes-mcp-server__clusters_switch",
+      "mcp__kubernetes-mcp-server__pods_list_in_namespace",
+      "mcp__kubernetes-mcp-server__pods_get",
+      "mcp__kubernetes-mcp-server__clusters_exec_all",
+      "mcp__kubernetes-mcp-server__pods_list",
+      "mcp__kubernetes-mcp-server__resources_get"
     ],
     "deny": [],
     "ask": [],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a fork of the Kubernetes MCP Server project, extended to support Rancher-based multi-cluster environments. The goal is to enable AI agents to interact with multiple Kubernetes clusters by reading kubeconfig files from a directory and using the KUBECONFIG environment variable to switch between clusters.
+This is a fork of the Kubernetes MCP Server project, extended to support Rancher-based multi-cluster environments. The goal is to enable AI agents to interact with multiple Kubernetes clusters by reading kubeconfig files from a directory and managing isolated client connections for each cluster.
 
 ### Key Technologies
 - **Go 1.24.1** - Main programming language
@@ -21,7 +21,7 @@ This is a fork of the Kubernetes MCP Server project, extended to support Rancher
 The NSK (Netskope Kubernetes) tool in `/Users/jdambly/repos/nsk` is used to download kubeconfig files for multiple clusters from Rancher. Key concepts:
 - Rancher API provides individual kubeconfig files per cluster
 - Files are typically stored in `~/.nsk/` directory with names like `c1-am2.yaml`, `c1-sv5.yaml`
-- The KUBECONFIG environment variable points to the active cluster config
+- Each cluster gets its own isolated client connection using its specific kubeconfig
 - NSK commands: `nsk cluster list`, `nsk cluster kubeconfig --name=cluster-name`
 
 ## Development Commands
@@ -116,7 +116,7 @@ The planned extension should:
 
 2. **Cluster Context Management**
    - Add tools to list available clusters
-   - Implement cluster switching via KUBECONFIG environment variable updates
+   - Implement cluster switching via isolated client managers per cluster
    - Enable cross-cluster operations (run same command on all clusters)
 
 3. **Enhanced MCP Tools**
@@ -149,8 +149,8 @@ Key files to modify for multi-cluster support:
 - `--port` - HTTP/SSE server mode
 
 ### Environment Variables
-- `KUBECONFIG` - Active cluster configuration (Rancher pattern)
-- Standard Kubernetes environment variables supported
+- Standard Kubernetes environment variables supported for cluster authentication
+- Each cluster uses its own isolated kubeconfig file (no global KUBECONFIG dependency)
 
 ## Testing Strategy
 

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -171,6 +171,14 @@ func (k *Kubernetes) ListClusters() []ClusterConfig {
 	return k.multiClusterManager.ListClusters()
 }
 
+// RefreshClusters refreshes the cluster list (multi-cluster mode only)
+func (k *Kubernetes) RefreshClusters(ctx context.Context) error {
+	if !k.IsMultiCluster() {
+		return fmt.Errorf("not in multi-cluster mode")
+	}
+	return k.multiClusterManager.RefreshClusters(ctx)
+}
+
 // StartMultiCluster starts the multi-cluster manager (multi-cluster mode only)
 func (k *Kubernetes) StartMultiCluster(ctx context.Context) error {
 	if !k.IsMultiCluster() {

--- a/pkg/kubernetes/multicluster_test.go
+++ b/pkg/kubernetes/multicluster_test.go
@@ -1,0 +1,515 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/klog/v2"
+
+	"github.com/containers/kubernetes-mcp-server/pkg/config"
+)
+
+func TestScanKubeConfigDirectory(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	// Create test kubeconfig files
+	testFiles := map[string]string{
+		"cluster1.yaml":                   "apiVersion: v1\nkind: Config",
+		"cluster2.yml":                    "apiVersion: v1\nkind: Config",
+		"stork-qa01-dp-npe-iad0-nc1.yaml": "apiVersion: v1\nkind: Config",
+		"stork-qa01-mp-npe-iad0-nc1.yaml": "apiVersion: v1\nkind: Config",
+		"stork-stg01-dp-iad0-nc4.yaml":    "apiVersion: v1\nkind: Config",
+		"stork-stg01-mp-iad0-nc4.yaml":    "apiVersion: v1\nkind: Config",
+		"not-a-yaml.txt":                  "this should be ignored",
+		"config.json":                     "this should also be ignored",
+	}
+
+	for filename, content := range testFiles {
+		filePath := filepath.Join(tempDir, filename)
+		err := os.WriteFile(filePath, []byte(content), 0644)
+		if err != nil {
+			t.Fatalf("Failed to create test file %s: %v", filename, err)
+		}
+	}
+
+	// Create subdirectory with files to test recursive scanning
+	subDir := filepath.Join(tempDir, "subdir")
+	err := os.Mkdir(subDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create subdirectory: %v", err)
+	}
+
+	subFilePath := filepath.Join(subDir, "subcluster.yaml")
+	err = os.WriteFile(subFilePath, []byte("apiVersion: v1\nkind: Config"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create subdirectory test file: %v", err)
+	}
+
+	// Set up test config
+	staticConfig := &config.StaticConfig{
+		KubeConfigDir: tempDir,
+	}
+
+	// Create MultiClusterManager
+	logger := klog.NewKlogr()
+	mcm := &MultiClusterManager{
+		staticConfig: staticConfig,
+		clusters:     make(map[string]*Manager),
+		logger:       logger,
+	}
+
+	// Test scanning
+	clusters, err := mcm.scanKubeConfigDirectory()
+	if err != nil {
+		t.Fatalf("scanKubeConfigDirectory failed: %v", err)
+	}
+
+	// Expected clusters (should find all .yaml and .yml files)
+	expectedClusters := map[string]bool{
+		"cluster1":                   true,
+		"cluster2":                   true,
+		"stork-qa01-dp-npe-iad0-nc1": true,
+		"stork-qa01-mp-npe-iad0-nc1": true,
+		"stork-stg01-dp-iad0-nc4":    true,
+		"stork-stg01-mp-iad0-nc4":    true,
+		"subcluster":                 true, // from subdirectory
+	}
+
+	if len(clusters) != len(expectedClusters) {
+		t.Errorf("Expected %d clusters, but found %d", len(expectedClusters), len(clusters))
+		t.Logf("Found clusters: %v", clusters)
+	}
+
+	for clusterName := range expectedClusters {
+		if _, found := clusters[clusterName]; !found {
+			t.Errorf("Expected cluster %s not found", clusterName)
+		}
+	}
+
+	// Verify paths are correct
+	for name, path := range clusters {
+		if !filepath.IsAbs(path) {
+			t.Errorf("Cluster %s path should be absolute, got: %s", name, path)
+		}
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Errorf("Cluster %s path does not exist: %s", name, path)
+		}
+	}
+}
+
+func TestScanKubeConfigDirectoryEmpty(t *testing.T) {
+	// Test with empty directory
+	tempDir := t.TempDir()
+
+	staticConfig := &config.StaticConfig{
+		KubeConfigDir: tempDir,
+	}
+
+	logger := klog.NewKlogr()
+	mcm := &MultiClusterManager{
+		staticConfig: staticConfig,
+		clusters:     make(map[string]*Manager),
+		logger:       logger,
+	}
+
+	clusters, err := mcm.scanKubeConfigDirectory()
+	if err != nil {
+		t.Fatalf("scanKubeConfigDirectory failed: %v", err)
+	}
+
+	if len(clusters) != 0 {
+		t.Errorf("Expected 0 clusters in empty directory, but found %d", len(clusters))
+	}
+}
+
+func TestScanKubeConfigDirectoryNotSet(t *testing.T) {
+	// Test with no directory set
+	staticConfig := &config.StaticConfig{
+		KubeConfigDir: "",
+	}
+
+	logger := klog.NewKlogr()
+	mcm := &MultiClusterManager{
+		staticConfig: staticConfig,
+		clusters:     make(map[string]*Manager),
+		logger:       logger,
+	}
+
+	clusters, err := mcm.scanKubeConfigDirectory()
+	if err != nil {
+		t.Fatalf("scanKubeConfigDirectory failed: %v", err)
+	}
+
+	if len(clusters) != 0 {
+		t.Errorf("Expected 0 clusters when no directory set, but found %d", len(clusters))
+	}
+}
+
+func TestScanKubeConfigDirectoryNonexistent(t *testing.T) {
+	// Test with nonexistent directory
+	staticConfig := &config.StaticConfig{
+		KubeConfigDir: "/nonexistent/path",
+	}
+
+	logger := klog.NewKlogr()
+	mcm := &MultiClusterManager{
+		staticConfig: staticConfig,
+		clusters:     make(map[string]*Manager),
+		logger:       logger,
+	}
+
+	clusters, err := mcm.scanKubeConfigDirectory()
+	if err == nil {
+		t.Errorf("Expected error for nonexistent directory, but got none")
+	}
+
+	if len(clusters) != 0 {
+		t.Errorf("Expected 0 clusters for nonexistent directory, but found %d", len(clusters))
+	}
+}
+
+func TestApplyClusterAliases(t *testing.T) {
+	staticConfig := &config.StaticConfig{
+		ClusterAliases: map[string]string{
+			"qa":          "stork-qa01-dp-npe-iad0-nc1",
+			"staging":     "stork-stg01-dp-iad0-nc4",
+			"nonexistent": "missing-cluster",
+		},
+	}
+
+	logger := klog.NewKlogr()
+	mcm := &MultiClusterManager{
+		staticConfig: staticConfig,
+		clusters:     make(map[string]*Manager),
+		logger:       logger,
+	}
+
+	originalClusters := map[string]string{
+		"stork-qa01-dp-npe-iad0-nc1": "/path/to/qa.yaml",
+		"stork-stg01-dp-iad0-nc4":    "/path/to/staging.yaml",
+		"other-cluster":              "/path/to/other.yaml",
+	}
+
+	aliasedClusters := mcm.applyClusterAliases(originalClusters)
+
+	// Should have original clusters plus aliases
+	expected := map[string]string{
+		"stork-qa01-dp-npe-iad0-nc1": "/path/to/qa.yaml",
+		"stork-stg01-dp-iad0-nc4":    "/path/to/staging.yaml",
+		"other-cluster":              "/path/to/other.yaml",
+		"qa":                         "/path/to/qa.yaml",      // alias
+		"staging":                    "/path/to/staging.yaml", // alias
+		// "nonexistent" should not be added because target doesn't exist
+	}
+
+	if len(aliasedClusters) != len(expected) {
+		t.Errorf("Expected %d clusters after aliases, but got %d", len(expected), len(aliasedClusters))
+	}
+
+	for name, expectedPath := range expected {
+		if actualPath, exists := aliasedClusters[name]; !exists {
+			t.Errorf("Expected cluster %s not found after applying aliases", name)
+		} else if actualPath != expectedPath {
+			t.Errorf("Cluster %s has wrong path: expected %s, got %s", name, expectedPath, actualPath)
+		}
+	}
+}
+
+func TestDiscoverClustersIntegration(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	// Create test kubeconfig files with minimal valid content
+	testFiles := map[string]string{
+		"stork-qa01-dp-npe-iad0-nc1.yaml": `apiVersion: v1
+kind: Config
+current-context: default
+contexts:
+- context:
+    cluster: default
+    user: default
+  name: default
+clusters:
+- cluster:
+    server: https://qa-cluster.example.com
+  name: default
+users:
+- name: default
+  user:
+    token: fake-token
+`,
+		"stork-qa01-mp-npe-iad0-nc1.yaml": `apiVersion: v1
+kind: Config
+current-context: default
+contexts:
+- context:
+    cluster: default
+    user: default
+  name: default
+clusters:
+- cluster:
+    server: https://mp-cluster.example.com
+  name: default
+users:
+- name: default
+  user:
+    token: fake-token
+`,
+	}
+
+	for filename, content := range testFiles {
+		filePath := filepath.Join(tempDir, filename)
+		err := os.WriteFile(filePath, []byte(content), 0644)
+		if err != nil {
+			t.Fatalf("Failed to create test file %s: %v", filename, err)
+		}
+	}
+
+	// Set up test config
+	staticConfig := &config.StaticConfig{
+		KubeConfigDir: tempDir,
+	}
+
+	// Create MultiClusterManager (without actually connecting to clusters)
+	logger := klog.NewKlogr()
+	mcm := &MultiClusterManager{
+		staticConfig: staticConfig,
+		clusters:     make(map[string]*Manager),
+		logger:       logger,
+	}
+
+	// Test discovery - this will fail on createClusterManager but should log the discovery part
+	ctx := context.Background()
+	err := mcm.DiscoverClusters(ctx)
+
+	// We expect this to fail because we can't actually connect to fake clusters,
+	// but it should discover the files correctly
+	t.Logf("DiscoverClusters result: %v", err)
+
+	// The scanning should have worked even if cluster creation failed
+	discoveredClusters, scanErr := mcm.scanKubeConfigDirectory()
+	if scanErr != nil {
+		t.Fatalf("Scan failed: %v", scanErr)
+	}
+
+	expectedClusters := []string{
+		"stork-qa01-dp-npe-iad0-nc1",
+		"stork-qa01-mp-npe-iad0-nc1",
+	}
+
+	if len(discoveredClusters) != len(expectedClusters) {
+		t.Errorf("Expected %d clusters, found %d", len(expectedClusters), len(discoveredClusters))
+	}
+
+	for _, expected := range expectedClusters {
+		if _, found := discoveredClusters[expected]; !found {
+			t.Errorf("Expected cluster %s not discovered", expected)
+		}
+	}
+}
+
+func TestSwitchCluster(t *testing.T) {
+	// Create test clusters
+	clusters := map[string]*Manager{
+		"cluster1": &Manager{
+			staticConfig: &config.StaticConfig{
+				KubeConfig: "/path/to/cluster1.yaml",
+			},
+		},
+		"cluster2": &Manager{
+			staticConfig: &config.StaticConfig{
+				KubeConfig: "/path/to/cluster2.yaml",
+			},
+		},
+	}
+
+	logger := klog.NewKlogr()
+	mcm := &MultiClusterManager{
+		staticConfig:  &config.StaticConfig{},
+		clusters:      clusters,
+		activeCluster: "cluster1",
+		logger:        logger,
+	}
+
+	// Test switching to existing cluster
+	err := mcm.SwitchCluster("cluster2")
+	if err != nil {
+		t.Errorf("SwitchCluster failed: %v", err)
+	}
+
+	if mcm.GetActiveCluster() != "cluster2" {
+		t.Errorf("Expected active cluster to be cluster2, got %s", mcm.GetActiveCluster())
+	}
+
+	// Test switching to non-existent cluster
+	err = mcm.SwitchCluster("nonexistent")
+	if err == nil {
+		t.Errorf("Expected error when switching to non-existent cluster")
+	}
+
+	// Active cluster should remain unchanged after failed switch
+	if mcm.GetActiveCluster() != "cluster2" {
+		t.Errorf("Active cluster should remain cluster2 after failed switch, got %s", mcm.GetActiveCluster())
+	}
+}
+
+func TestSwitchClusterValidation(t *testing.T) {
+	logger := klog.NewKlogr()
+
+	// Test with nil manager
+	mcm := &MultiClusterManager{
+		staticConfig: &config.StaticConfig{},
+		clusters: map[string]*Manager{
+			"invalid": nil,
+		},
+		logger: logger,
+	}
+
+	err := mcm.SwitchCluster("invalid")
+	if err == nil {
+		t.Errorf("Expected error when switching to cluster with nil manager")
+	}
+
+	// Test with manager having nil config
+	mcm.clusters["invalid"] = &Manager{
+		staticConfig: nil,
+	}
+
+	err = mcm.SwitchCluster("invalid")
+	if err == nil {
+		t.Errorf("Expected error when switching to cluster with nil config")
+	}
+
+	// Test with manager having empty kubeconfig
+	mcm.clusters["invalid"] = &Manager{
+		staticConfig: &config.StaticConfig{
+			KubeConfig: "",
+		},
+	}
+
+	err = mcm.SwitchCluster("invalid")
+	if err == nil {
+		t.Errorf("Expected error when switching to cluster with empty kubeconfig")
+	}
+}
+
+func TestGetActiveManager(t *testing.T) {
+	clusters := map[string]*Manager{
+		"cluster1": &Manager{
+			staticConfig: &config.StaticConfig{
+				KubeConfig: "/path/to/cluster1.yaml",
+			},
+		},
+		"cluster2": &Manager{
+			staticConfig: &config.StaticConfig{
+				KubeConfig: "/path/to/cluster2.yaml",
+			},
+		},
+	}
+
+	logger := klog.NewKlogr()
+	mcm := &MultiClusterManager{
+		staticConfig:  &config.StaticConfig{},
+		clusters:      clusters,
+		activeCluster: "cluster1",
+		logger:        logger,
+	}
+
+	// Test getting active manager
+	manager, err := mcm.GetActiveManager()
+	if err != nil {
+		t.Errorf("GetActiveManager failed: %v", err)
+	}
+
+	if manager != clusters["cluster1"] {
+		t.Errorf("Expected manager for cluster1, got different manager")
+	}
+
+	// Test with no active cluster
+	mcm.activeCluster = ""
+	_, err = mcm.GetActiveManager()
+	if err == nil {
+		t.Errorf("Expected error when no active cluster is set")
+	}
+
+	// Test with active cluster not found
+	mcm.activeCluster = "nonexistent"
+	_, err = mcm.GetActiveManager()
+	if err == nil {
+		t.Errorf("Expected error when active cluster doesn't exist")
+	}
+}
+
+func TestConcurrentClusterSwitching(t *testing.T) {
+	clusters := map[string]*Manager{
+		"cluster1": &Manager{
+			staticConfig: &config.StaticConfig{KubeConfig: "/path/to/cluster1.yaml"},
+		},
+		"cluster2": &Manager{
+			staticConfig: &config.StaticConfig{KubeConfig: "/path/to/cluster2.yaml"},
+		},
+		"cluster3": &Manager{
+			staticConfig: &config.StaticConfig{KubeConfig: "/path/to/cluster3.yaml"},
+		},
+	}
+
+	logger := klog.NewKlogr()
+	mcm := &MultiClusterManager{
+		staticConfig:  &config.StaticConfig{},
+		clusters:      clusters,
+		activeCluster: "cluster1",
+		logger:        logger,
+	}
+
+	const numGoroutines = 10
+	const numSwitches = 100
+
+	// Run concurrent cluster switches
+	done := make(chan bool, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			defer func() { done <- true }()
+
+			for j := 0; j < numSwitches; j++ {
+				clusterName := fmt.Sprintf("cluster%d", (j%3)+1)
+				err := mcm.SwitchCluster(clusterName)
+				if err != nil {
+					t.Errorf("Goroutine %d: SwitchCluster failed: %v", id, err)
+					return
+				}
+
+				// Verify we can get the active manager
+				_, err = mcm.GetActiveManager()
+				if err != nil {
+					t.Errorf("Goroutine %d: GetActiveManager failed: %v", id, err)
+					return
+				}
+			}
+		}(i)
+	}
+
+	// Wait for all goroutines to complete
+	for i := 0; i < numGoroutines; i++ {
+		<-done
+	}
+
+	// Verify final state is consistent
+	activeCluster := mcm.GetActiveCluster()
+	if activeCluster == "" {
+		t.Errorf("Active cluster should not be empty after concurrent switching")
+	}
+
+	manager, err := mcm.GetActiveManager()
+	if err != nil {
+		t.Errorf("Should be able to get active manager after concurrent switching: %v", err)
+	}
+
+	if manager == nil {
+		t.Errorf("Active manager should not be nil")
+	}
+}


### PR DESCRIPTION
## Summary
Fixes the cluster switching timeout issue where the MCP server would hang and not return a response when switching between Kubernetes clusters.

## Problem
When using the `clusters_switch` tool, users experienced:
- Request timeouts (MCP error -32001)
- No response from the server
- Hanging operations

## Root Cause
Two blocking API calls that could hang indefinitely:
1. `validateManagerAuthentication()` in `reloadKubernetesClient()` - performed synchronous auth check
2. `performHealthCheck()` in `SwitchCluster()` - performed synchronous health validation

Both called `ServerVersion()` without timeout context, blocking the response when Kubernetes API servers were slow/unreachable.

## Solution
- ✅ Removed blocking `validateManagerAuthentication()` call from `reloadKubernetesClient()`
- ✅ Removed synchronous `performHealthCheck()` call from `SwitchCluster()`
- ✅ Health checks still occur asynchronously via background health monitor
- ✅ Added comprehensive logging throughout cluster discovery and switching

## Changes
- `pkg/mcp/mcp.go`: Removed synchronous authentication validation
- `pkg/kubernetes/multicluster.go`: Removed blocking health check, enhanced logging and error handling

## Testing
✅ Tested cluster switching with `clusters_switch` tool - immediate response
✅ Successfully switches between clusters without timeouts
✅ Background health monitoring continues to validate cluster accessibility

## Tag
`v0.0.50`